### PR TITLE
ci: clean up workflows

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -18,7 +18,7 @@ jobs:
       uses: actions/setup-python@v5.1.0
       with:
         python-version: 3.12
-        cache: pipenv
+        cache: pip
 
     - name: Install dependencies
       run: pip install -r requirements.txt

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -2,24 +2,26 @@ name: Pylint
 
 on:
   push:
-    branches: [ "main" ]
+    branches: main
   pull_request:
-    branches: [ "main" ]
+    branches: main
 
 jobs:
   linter:
     runs-on: ubuntu-latest
-    
+
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v3
+    - name: Checkout repository
+      uses: actions/checkout@v4.1.6
+
+    - name: Setup Python
+      uses: actions/setup-python@v5.1.0
       with:
-        python-version: "3.10"
+        python-version: 3.12
+        cache: pipenv
+
     - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
+      run: pip install -r requirements.txt
+
     - name: Analysing the code with pylint
-      run: |
-        pylint $(git ls-files '*.py')
+      run: pylint --recursive=y .

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,13 +1,10 @@
-# This workflow will install Python dependencies, run tests and lint with a single version of Python
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
-
 name: Pytest
 
 on:
   push:
-    branches: [ "main" ]
+    branches: main
   pull_request:
-    branches: [ "main" ]
+    branches: main
 
 permissions:
   contents: read
@@ -16,15 +13,17 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v3
+    - name: Checkout repository
+      uses: actions/checkout@v4.1.6
+
+    - name: Setup Python
+      uses: actions/setup-python@v5.1.0
       with:
-        python-version: "3.10"
+        python-version: 3.12
+        cache: pipenv
+
     - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
+      run: pip install -r requirements.txt
+
     - name: Test with pytest
-      run: |
-        pytest test_pytest.py
+      run: pytest test_pytest.py

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -20,7 +20,7 @@ jobs:
       uses: actions/setup-python@v5.1.0
       with:
         python-version: 3.12
-        cache: pipenv
+        cache: pip
 
     - name: Install dependencies
       run: pip install -r requirements.txt


### PR DESCRIPTION
## Summary

In this PR, we pin the exact workflow action versions. This will help with Dependabot bumping if we do implement it in the future. We also cache our `pipenv` dependencies to improve workflow times.

Closes #23 