### PR TITLE
build: use preferred docker conventions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11
+FROM python:3.12-slim
 
 WORKDIR /app
 ADD . /app

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   web:
     build: .
@@ -6,6 +5,6 @@ services:
     volumes:
       - .:/app
     ports:
-      - "5001:5000"
+      - 5001:5000
     environment:
       - FLASK_ENV=development


### PR DESCRIPTION
## Summary

Docker recommends compose files to be `compose.yaml` instead of `docker-compose.yml`. The `version` tag is also now deprecated. For performance, we should try to use `-slim` images whenever possible, and since our codebase is compatible with Python 3.12, we can bump the version as well.

Closes #32